### PR TITLE
[AE-36] SMS tab view - Add ability for user to send messages

### DIFF
--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -57,6 +57,7 @@
     "docx": "^9.1.0",
     "file-saver": "^2.0.5",
     "local-cors-proxy": "^1.1.0",
+    "react-textarea-autosize": "^8.5.9",
     "recoil-sync": "^0.2.0",
     "transliteration": "^2.3.5",
     "twenty-shared": "workspace:*",

--- a/packages/twenty-front/src/modules/activities/smstexts/components/SMSTextCard.tsx
+++ b/packages/twenty-front/src/modules/activities/smstexts/components/SMSTextCard.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @nx/workspace-no-hardcoded-colors */
-import { SMSText as SMSTextCardProps } from '@/activities/types/SMSText';
+import { SMSTextCardProps } from '@/activities/smstexts/components/types/SMSTextProps';
 import styled from '@emotion/styled';
 import { formatToHumanReadableDate } from '~/utils/date-utils';
 
@@ -14,7 +14,9 @@ const StyledMessage = styled.div`
   position: relative;
   overflow-wrap: break-word;
 `;
-// eslint-disable-next-line @nx/workspace-no-hardcoded-colors
+const StyledAgentName = styled.span`
+  align-self: flex-end;
+`;
 const StyledAgentMessage = styled(StyledMessage)<any>`
   align-self: flex-end;
   background-color: #dcf8c6; /* Light green */
@@ -24,13 +26,6 @@ const StyledCustomerMessage = styled(StyledMessage)<any>`
   align-self: flex-start;
   background-color: #f1f0f0; /* Light gray */
   border-bottom-left-radius: 0;
-`;
-const StyledSenderName = styled.span`
-  display: flex;
-  margin: ${({ theme }) => theme.spacing(0, 1)};
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 `;
 const StyledBody = styled.span`
   color: ${({ theme }) => theme.font.color.tertiary};
@@ -42,23 +37,32 @@ const StyledReceivedAt = styled.div`
   margin-left: auto;
 `;
 
-export const SMSTextCard = ({ sender, body, date }: SMSTextCardProps) => {
-  // check if sender is the customer
-  if (sender === '+16179997801') {
+export const SMSTextCard = ({ text, userViewed }: SMSTextCardProps) => {
+  // Check if sender is the customer
+  if (text.sender === userViewed.phone) {
     return (
-      <StyledCustomerMessage>
-        <StyledSenderName>{sender}</StyledSenderName>
-        <StyledBody>{body}</StyledBody>
-        <StyledReceivedAt>{formatToHumanReadableDate(date)}</StyledReceivedAt>
-      </StyledCustomerMessage>
+      <>
+        {userViewed.name}
+        <StyledCustomerMessage>
+          <StyledBody>{text.body}</StyledBody>
+          <StyledReceivedAt>
+            {formatToHumanReadableDate(text.date)}
+          </StyledReceivedAt>
+        </StyledCustomerMessage>
+      </>
     );
   } else {
+    // Hardcoded agent name - should pull from logged in user data
     return (
-      <StyledAgentMessage>
-        <StyledSenderName>{sender}</StyledSenderName>
-        <StyledBody>{body}</StyledBody>
-        <StyledReceivedAt>{formatToHumanReadableDate(date)}</StyledReceivedAt>
-      </StyledAgentMessage>
+      <>
+        <StyledAgentName>{'Agent Name'}</StyledAgentName>
+        <StyledAgentMessage>
+          <StyledBody>{text.body}</StyledBody>
+          <StyledReceivedAt>
+            {formatToHumanReadableDate(text.date)}
+          </StyledReceivedAt>
+        </StyledAgentMessage>
+      </>
     );
   }
 };

--- a/packages/twenty-front/src/modules/activities/smstexts/components/SMSTextCard.tsx
+++ b/packages/twenty-front/src/modules/activities/smstexts/components/SMSTextCard.tsx
@@ -8,8 +8,8 @@ const StyledMessage = styled.div`
   border-radius: 1.5rem;
   display: flex;
   gap: ${({ theme }) => theme.spacing(2)};
-  /* height: ${({ theme }) => theme.spacing(12)}; */
   max-width: 60%;
+  // TODO: calc from theme
   padding: 0.75rem 1rem;
   position: relative;
   overflow-wrap: break-word;

--- a/packages/twenty-front/src/modules/activities/smstexts/components/SMSTextCard.tsx
+++ b/packages/twenty-front/src/modules/activities/smstexts/components/SMSTextCard.tsx
@@ -1,0 +1,64 @@
+/* eslint-disable @nx/workspace-no-hardcoded-colors */
+import { SMSText as SMSTextCardProps } from '@/activities/types/SMSText';
+import styled from '@emotion/styled';
+import { formatToHumanReadableDate } from '~/utils/date-utils';
+
+const StyledMessage = styled.div`
+  align-items: center;
+  border-radius: 1.5rem;
+  display: flex;
+  gap: ${({ theme }) => theme.spacing(2)};
+  /* height: ${({ theme }) => theme.spacing(12)}; */
+  max-width: 60%;
+  padding: 0.75rem 1rem;
+  position: relative;
+  overflow-wrap: break-word;
+`;
+// eslint-disable-next-line @nx/workspace-no-hardcoded-colors
+const StyledAgentMessage = styled(StyledMessage)<any>`
+  align-self: flex-end;
+  background-color: #dcf8c6; /* Light green */
+  border-bottom-right-radius: 0;
+`;
+const StyledCustomerMessage = styled(StyledMessage)<any>`
+  align-self: flex-start;
+  background-color: #f1f0f0; /* Light gray */
+  border-bottom-left-radius: 0;
+`;
+const StyledSenderName = styled.span`
+  display: flex;
+  margin: ${({ theme }) => theme.spacing(0, 1)};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+const StyledBody = styled.span`
+  color: ${({ theme }) => theme.font.color.tertiary};
+`;
+const StyledReceivedAt = styled.div`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.regular};
+  padding: ${({ theme }) => theme.spacing(0, 1)};
+  margin-left: auto;
+`;
+
+export const SMSTextCard = ({ sender, body, date }: SMSTextCardProps) => {
+  // check if sender is the customer
+  if (sender === '+16179997801') {
+    return (
+      <StyledCustomerMessage>
+        <StyledSenderName>{sender}</StyledSenderName>
+        <StyledBody>{body}</StyledBody>
+        <StyledReceivedAt>{formatToHumanReadableDate(date)}</StyledReceivedAt>
+      </StyledCustomerMessage>
+    );
+  } else {
+    return (
+      <StyledAgentMessage>
+        <StyledSenderName>{sender}</StyledSenderName>
+        <StyledBody>{body}</StyledBody>
+        <StyledReceivedAt>{formatToHumanReadableDate(date)}</StyledReceivedAt>
+      </StyledAgentMessage>
+    );
+  }
+};

--- a/packages/twenty-front/src/modules/activities/smstexts/components/SMSTexts.tsx
+++ b/packages/twenty-front/src/modules/activities/smstexts/components/SMSTexts.tsx
@@ -34,12 +34,12 @@ const StyledContainer = styled.div`
 const StyledScrollableContainer = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: ${({ theme }) => theme.spacing(2)};
   margin: 0 auto;
-  // TODO: calculate from theme spacing
-  max-height: 60vh;
+  // TODO: in full record view - the log should take up more vertical space. how to use percents here if parent is not fixed
+  height: ${({ theme }) => theme.spacing(105)};
   overflow: auto;
-  font-family: sans-serif;
+  font-family: inherit;
 `;
 const StyledH1Title = styled(H1Title)`
   display: flex;
@@ -49,26 +49,29 @@ const StyledTextCount = styled.span`
   color: ${({ theme }) => theme.font.color.light};
 `;
 const StyledMessageSendContainer = styled.div`
-  justify-content: flex-end;
+  align-items: center;
   display: flex;
-  flex-direction: row;
+  float: right;
+  justify-content: flex-end;
   margin: ${({ theme }) => theme.spacing(6, 0)};
+  // Same as messages
+  width: 60%;
 `;
-const StyledInput = styled.input`
-  flex: 1;
+const StyledTextArea = styled.textarea`
   border: 1px solid;
   border-radius: 1.5rem;
-  background-color: transparent;
+  flex: 1;
+  font-family: inherit;
   font-size: ${({ theme }) => theme.font.size.md};
   margin-right: ${({ theme }) => theme.spacing(5)};
   padding: ${({ theme }) => theme.spacing(2)};
-  max-width: ${({ theme }) => theme.spacing(50)};
+  resize: none;
 `;
 const StyledButton = styled.button`
   background: ${({ theme }) => theme.background.transparent.light};
   border: 1px solid ${({ theme }) => theme.border.color.medium};
   border-radius: ${({ theme }) => theme.border.radius.md};
-  align-items: center;
+  height: 50%;
   padding: ${({ theme }) => theme.spacing(2, 4)};
 `;
 
@@ -168,17 +171,18 @@ export const SMSTexts = ({
   };
 
   // Send message handlers
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setSendMessageBox(event.target.value);
   };
-  const handleEnter = (event: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleEnter = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === 'Enter') {
+      event.preventDefault();
       handleSend();
     }
   };
   const handleSend = () => {
+    sendText(sendMessageBox.trim());
     setSendMessageBox('');
-    sendText(sendMessageBox);
   };
 
   // Get info for current user being viewed
@@ -258,12 +262,13 @@ export const SMSTexts = ({
           ))}
         </StyledScrollableContainer>
         <StyledMessageSendContainer>
-          <StyledInput
-            placeholder={'Text message'}
+          <StyledTextArea
+            placeholder={'Enter message'}
             value={sendMessageBox}
             onChange={handleInputChange}
             onKeyDown={handleEnter}
-          ></StyledInput>
+            rows={2}
+          ></StyledTextArea>
           <StyledButton onClick={handleSend}>Send</StyledButton>
         </StyledMessageSendContainer>
       </Section>

--- a/packages/twenty-front/src/modules/activities/smstexts/components/SMSTexts.tsx
+++ b/packages/twenty-front/src/modules/activities/smstexts/components/SMSTexts.tsx
@@ -1,28 +1,36 @@
-import { ActivityList } from '@/activities/components/ActivityList';
-import { ActivityRow } from '@/activities/components/ActivityRow';
+import { SMSTextCard } from '@/activities/smstexts/components/SMSTextCard';
 import { ActivityTargetableObject } from '@/activities/types/ActivityTargetableEntity';
-import { SMSText, TwilioMessage } from '@/activities/types/SMSText';
+import {
+  SMSText as SMSTextType,
+  TwilioMessage,
+} from '@/activities/types/SMSText';
+
 import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
 import { Person } from '@/people/types/Person';
 import styled from '@emotion/styled';
 import axios from 'axios';
 import { useEffect, useRef, useState } from 'react';
 import { H1Title, H1TitleFontColor, Section } from 'twenty-ui';
-import { formatToHumanReadableDate } from '~/utils/date-utils';
 
 // Styled components copied from EmailThread
 const StyledContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${({ theme }) => theme.spacing(6)};
-  padding: ${({ theme }) => theme.spacing(6, 6, 2)};
-  height: 100%;
+  padding: ${({ theme }) => theme.spacing(6, 6, 0, 6)};
+  height: 97%;
   overflow: auto;
 `;
 
 const StyledScrollableContainer = styled.div`
-  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0 auto;
+  max-height: 60vh;
+  max-width: 50vh;
   overflow: auto;
+  font-family: sans-serif;
 `;
 const StyledH1Title = styled(H1Title)`
   display: flex;
@@ -30,25 +38,6 @@ const StyledH1Title = styled(H1Title)`
 `;
 const StyledTextCount = styled.span`
   color: ${({ theme }) => theme.font.color.light};
-`;
-const StyledSenderNames = styled.span`
-  display: flex;
-  margin: ${({ theme }) => theme.spacing(0, 1)};
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
-const StyledBody = styled.span`
-  color: ${({ theme }) => theme.font.color.tertiary};
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
-const StyledReceivedAt = styled.div`
-  font-size: ${({ theme }) => theme.font.size.sm};
-  font-weight: ${({ theme }) => theme.font.weight.regular};
-  padding: ${({ theme }) => theme.spacing(0, 1)};
-  margin-left: auto;
 `;
 
 export const SMSTexts = ({
@@ -79,6 +68,7 @@ export const SMSTexts = ({
       const personPhoneNumber = `${person.phones.primaryPhoneCallingCode}${person.phones.primaryPhoneNumber}`;
 
       try {
+        // currently doesn't filter for delivered success status
         const [toResponse, fromResponse] = await Promise.all([
           await axios.get(
             `${apiUrl}/2010-04-01/Accounts/${accountSid}/Messages.json?To=${personPhoneNumber}`,
@@ -145,18 +135,10 @@ export const SMSTexts = ({
         />
 
         <StyledScrollableContainer ref={scrollRef}>
-          <ActivityList>
-            {transformedTexts?.map((text: SMSText) => (
-              // can't click on each text
-              <ActivityRow onClick={() => {}} key={text.id}>
-                <StyledSenderNames>{text.sender}</StyledSenderNames>
-                <StyledBody>{text.body}</StyledBody>
-                <StyledReceivedAt>
-                  {formatToHumanReadableDate(text.date)}
-                </StyledReceivedAt>
-              </ActivityRow>
-            ))}
-          </ActivityList>
+          {transformedTexts?.map((text: SMSTextType) => (
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            <SMSTextCard {...text} key={text.id}></SMSTextCard>
+          ))}
         </StyledScrollableContainer>
       </Section>
     </StyledContainer>

--- a/packages/twenty-front/src/modules/activities/smstexts/components/SMSTexts.tsx
+++ b/packages/twenty-front/src/modules/activities/smstexts/components/SMSTexts.tsx
@@ -12,6 +12,7 @@ import { Person } from '@/people/types/Person';
 import styled from '@emotion/styled';
 import axios from 'axios';
 import { useEffect, useRef, useState } from 'react';
+import TextareaAutosize from 'react-textarea-autosize';
 import {
   AnimatedPlaceholder,
   AnimatedPlaceholderEmptyContainer,
@@ -24,12 +25,12 @@ import {
   Section,
 } from 'twenty-ui';
 
-// Some styled components copied from EmailThread
 const StyledContainer = styled.div`
   display: flex;
   flex-direction: column;
   padding: ${({ theme }) => theme.spacing(6, 6, 0, 6)};
-  overflow: auto;
+  // Override padding-bottom from ShowPageSubContainer
+  margin-bottom: ${({ theme }) => theme.spacing(-16)};
 `;
 const StyledScrollableContainer = styled.div`
   display: flex;
@@ -57,12 +58,11 @@ const StyledMessageSendContainer = styled.div`
   // Same as messages
   width: 60%;
 `;
-const StyledTextArea = styled.textarea`
+const StyledTextArea = styled(TextareaAutosize)`
   border: 1px solid;
   border-radius: 1.5rem;
   flex: 1;
   font-family: inherit;
-  font-size: ${({ theme }) => theme.font.size.md};
   margin-right: ${({ theme }) => theme.spacing(5)};
   padding: ${({ theme }) => theme.spacing(2)};
   resize: none;
@@ -73,6 +73,9 @@ const StyledButton = styled.button`
   border-radius: ${({ theme }) => theme.border.radius.md};
   height: 50%;
   padding: ${({ theme }) => theme.spacing(2, 4)};
+  :hover {
+    background: ${({ theme }) => theme.background.transparent.medium};
+  }
 `;
 
 export const SMSTexts = ({
@@ -217,7 +220,7 @@ export const SMSTexts = ({
     // Sort in ascending order by date
     .sort((a, b) => new Date(a.date).valueOf() - new Date(b.date).valueOf());
 
-  // Loading screen or no records
+  // Display loading screen or no records
   if (!isFetchDone) {
     return <SkeletonLoader />;
   } else if (transformedTexts.length === 0) {

--- a/packages/twenty-front/src/modules/activities/smstexts/components/types/SMSTextProps.ts
+++ b/packages/twenty-front/src/modules/activities/smstexts/components/types/SMSTextProps.ts
@@ -1,0 +1,11 @@
+import { SMSText } from '@/activities/types/SMSText';
+
+export type SMSTextCardProps = {
+  text: SMSText;
+  userViewed: UserViewed;
+};
+
+export type UserViewed = {
+  phone: string;
+  name: string;
+};

--- a/packages/twenty-front/src/modules/activities/types/SMSText.ts
+++ b/packages/twenty-front/src/modules/activities/types/SMSText.ts
@@ -1,13 +1,13 @@
 export type SMSText = {
-    id: string;
-    sender: string;
-    body: string;
-    date: Date;
+  id: string;
+  sender: string;
+  body: string;
+  date: Date;
 };
 
 export type TwilioMessage = {
-    sid: string;
-    from: string;
-    body: string;
-    date_sent: string | Date; 
+  sid: string;
+  from: string;
+  body: string;
+  date_sent: string | Date;
 };


### PR DESCRIPTION
- Add text box for user input below message log history
- User can press enter key or hit Send button to send the message
- No auto-polling yet, so user must refresh page to see new message

- Styling changes: Display loading screen, empty message log, messages a la iMessage UI, text box autoresizes based on content
- Other: Get message history based on current user viewed's phone number / remove hard-coded number

[Jira ticket](https://truewhitespace.atlassian.net/browse/AE-36?atlOrigin=eyJpIjoiYjA1OTA5ZDUzMTM0NGI2YjlhYWNhMzY0NGUwNmI4OGEiLCJwIjoiaiJ9)